### PR TITLE
filter for month wintitle stat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog 更新日志
 
+## 0.0.12
+> 2024-04-21
+- 添加了月度统计中对窗口标题的过滤，现在可以查看具体关于某件事的屏幕时间了；
+- Added filtering for window titles in monthly statistics, now you can view screen time specifically about something;
+
 ## 0.0.11
 > 2024-04-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog 更新日志
 
-## 0.0.12 - not pushed
+## 0.0.12
 > 2024-04-21
 - 添加了月度统计中对窗口标题的过滤，现在可以查看具体关于某件事的屏幕时间了；
 - Added filtering for window titles in monthly statistics, now you can view screen time specifically about something;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog 更新日志
 
-## 0.0.12
+## 0.0.12 - not pushed
 > 2024-04-21
 - 添加了月度统计中对窗口标题的过滤，现在可以查看具体关于某件事的屏幕时间了；
 - Added filtering for window titles in monthly statistics, now you can view screen time specifically about something;

--- a/windrecorder/__init__.py
+++ b/windrecorder/__init__.py
@@ -1,2 +1,2 @@
 # we only use `b`, no `a` and `rc`
-__version__ = "0.0.11"
+__version__ = "0.0.12"

--- a/windrecorder/config_src/languages.json
+++ b/windrecorder/config_src/languages.json
@@ -82,6 +82,8 @@
         "stat_text_generating_lightbox": "Generating, it might takes about 5s...",
         "stat_text_no_month_lightbox": "No lightbox image for this month.",
         "stat_text_counting": "Counting...",
+        "stat_text_wintitle_keyword_filter": "Keyword filter",
+        "stat_text_wintitle_filter_help": "Separate multiple keywords by spaces to search. Case will be ignored when searching for keywords. Leave blank to list all data for the current month.",
 
         "rs_text_need_to_restart_after_save_setting": "After saving the settings on this page, you need to restart 'Windrecorder' to take effect.",
         "rs_md_title": "### 📼 Recording & Video Storage",
@@ -314,6 +316,8 @@
         "stat_text_generating_lightbox": "生成中，大概需要 5s……",
         "stat_text_no_month_lightbox": "当月未有光箱图片。",
         "stat_text_counting": "统计中……",
+        "stat_text_wintitle_keyword_filter": "关键词过滤",
+        "stat_text_wintitle_filter_help": "通过空格分开多个关键词进行检索，关键词搜索时会忽略大小写。留空列出当月所有数据。",
 
         "rs_text_need_to_restart_after_save_setting": "本页的设置在保存后，需重启 「捕风记录仪」 才能生效。",
         "rs_md_title": "### 📼 录制与视频存储",
@@ -546,6 +550,8 @@
         "stat_text_generating_lightbox": "生成中です。約 5秒かかります...",
         "stat_text_no_month_lightbox": "今月はライトボックス画像がありません。",
         "stat_text_counting": "統計...",
+        "stat_text_wintitle_keyword_filter": "キーワード フィルター",
+        "stat_text_wintitle_filter_help": "キーワードを検索する場合、複数のキーワードをスペースで区切って検索します。 当月のすべてのデータをリストするには、空白のままにします。",
 
         "rs_text_need_to_restart_after_save_setting": "このページの設定を保存した後、Windrecorder を再起動する必要があります。",
         "rs_md_title": "### 📼 録画とビデオストレージ",

--- a/windrecorder/record_wintitle.py
+++ b/windrecorder/record_wintitle.py
@@ -256,7 +256,7 @@ def component_month_wintitle_stat(month_dt: datetime.datetime):
     if "month_wintitle_filter_lazy" not in st.session_state:
         st.session_state.month_wintitle_filter_lazy = ""
     if "month_wintitle_df_fliter" not in st.session_state:
-        st.session_state["month_wintitle_df_fliter"] = None
+        st.session_state["month_wintitle_df_fliter"] = pd.DataFrame()
     if "month_wintitle_df_fliter_screentime_sum" not in st.session_state:
         st.session_state["month_wintitle_df_fliter_screentime_sum"] = 0
 
@@ -308,7 +308,6 @@ def component_month_wintitle_stat(month_dt: datetime.datetime):
             res_dict = _filter_stat_by_keywords_match(st.session_state.month_wintitle_filter)
             st.session_state["month_wintitle_df_fliter"] = turn_dict_into_display_dataframe(res_dict)
             st.session_state["month_wintitle_df_fliter_screentime_sum"] = sum(int(value) for value in res_dict.values())
-
             st.session_state.month_wintitle_filter_lazy = st.session_state.month_wintitle_filter
 
     if st.session_state[month_wintitle_df_statename].empty or update_condition:
@@ -336,7 +335,7 @@ def component_month_wintitle_stat(month_dt: datetime.datetime):
 
     # ---ui drawing
     st.session_state.month_wintitle_filter = st.text_input(
-        label=_t("stat_text_wintitle_keyword_filter"), help=_t("stat_text_wintitle_filter_help")
+        label="🧩 " + _t("stat_text_wintitle_keyword_filter"), help=_t("stat_text_wintitle_filter_help")
     )
 
     if len(st.session_state[month_wintitle_df_statename]) > 0 and len(st.session_state.month_wintitle_filter) == 0:
@@ -360,6 +359,7 @@ def component_month_wintitle_stat(month_dt: datetime.datetime):
         st.markdown(f"`{current_month_wintitle_stat_json_filepath}`")
     elif len(st.session_state.month_wintitle_filter) > 0:
         _update_filter_stat_by_keywords_res()
+
         st.dataframe(
             st.session_state["month_wintitle_df_fliter"],
             column_config={

--- a/windrecorder/record_wintitle.py
+++ b/windrecorder/record_wintitle.py
@@ -309,6 +309,8 @@ def component_month_wintitle_stat(month_dt: datetime.datetime):
             int(value) for value in st.session_state["month_wintitle_stat_dict"].values()
         )
 
+    st.session_state.month_wintitle_filter = st.text_input(label="filter")
+
     if len(st.session_state[month_wintitle_df_statename]) > 0:
         st.dataframe(
             st.session_state[month_wintitle_df_statename],


### PR DESCRIPTION
给月度的窗口标题统计增加一个过滤搜索框，可以过滤出表中包含关键词的内容、统计它们的总时长。
现有生成统计时间表的逻辑有些耦合了，数据可能没法重新灵活进行计算使用。