### PR TITLE
add record audio support

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2172,6 +2172,34 @@ url = "https://pypi.org/simple"
 reference = "pypi-default"
 
 [[package]]
+name = "pyaudio"
+version = "0.2.14"
+description = "Cross-platform audio I/O with PortAudio"
+optional = false
+python-versions = "*"
+files = [
+    {file = "PyAudio-0.2.14-cp310-cp310-win32.whl", hash = "sha256:126065b5e82a1c03ba16e7c0404d8f54e17368836e7d2d92427358ad44fefe61"},
+    {file = "PyAudio-0.2.14-cp310-cp310-win_amd64.whl", hash = "sha256:2a166fc88d435a2779810dd2678354adc33499e9d4d7f937f28b20cc55893e83"},
+    {file = "PyAudio-0.2.14-cp311-cp311-win32.whl", hash = "sha256:506b32a595f8693811682ab4b127602d404df7dfc453b499c91a80d0f7bad289"},
+    {file = "PyAudio-0.2.14-cp311-cp311-win_amd64.whl", hash = "sha256:bbeb01d36a2f472ae5ee5e1451cacc42112986abe622f735bb870a5db77cf903"},
+    {file = "PyAudio-0.2.14-cp312-cp312-win32.whl", hash = "sha256:5fce4bcdd2e0e8c063d835dbe2860dac46437506af509353c7f8114d4bacbd5b"},
+    {file = "PyAudio-0.2.14-cp312-cp312-win_amd64.whl", hash = "sha256:12f2f1ba04e06ff95d80700a78967897a489c05e093e3bffa05a84ed9c0a7fa3"},
+    {file = "PyAudio-0.2.14-cp38-cp38-win32.whl", hash = "sha256:858caf35b05c26d8fc62f1efa2e8f53d5fa1a01164842bd622f70ddc41f55000"},
+    {file = "PyAudio-0.2.14-cp38-cp38-win_amd64.whl", hash = "sha256:2dac0d6d675fe7e181ba88f2de88d321059b69abd52e3f4934a8878e03a7a074"},
+    {file = "PyAudio-0.2.14-cp39-cp39-win32.whl", hash = "sha256:f745109634a7c19fa4d6b8b7d6967c3123d988c9ade0cd35d4295ee1acdb53e9"},
+    {file = "PyAudio-0.2.14-cp39-cp39-win_amd64.whl", hash = "sha256:009f357ee5aa6bc8eb19d69921cd30e98c42cddd34210615d592a71d09c4bd57"},
+    {file = "PyAudio-0.2.14.tar.gz", hash = "sha256:78dfff3879b4994d1f4fc6485646a57755c6ee3c19647a491f790a0895bd2f87"},
+]
+
+[package.extras]
+test = ["numpy"]
+
+[package.source]
+type = "legacy"
+url = "https://pypi.org/simple"
+reference = "pypi-default"
+
+[[package]]
 name = "pyclipper"
 version = "1.3.0.post5"
 description = "Cython wrapper for the C++ translation of the Angus Johnson's Clipper library (ver. 6.4.2)"
@@ -3705,4 +3733,4 @@ reference = "pypi-default"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.12"
-content-hash = "4d90607fc8c9e00368cebab2052b0b852ba6a084ba3c49ba2712bb2f385a0d40"
+content-hash = "27d29f34fafb55629f13b7e8f059732b65adaeebf3ad8323cf798a005d832c64"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ streamlit-tags = "^1.2.8"
 mss = "^9.0.1"
 pygetwindow = "^0.0.9"
 uiautomation = "^2.0.20"
+pyaudio = "^0.2.14"
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = "^3.5.0"

--- a/windrecorder/config.py
+++ b/windrecorder/config.py
@@ -98,6 +98,7 @@ class Config:
         convert_screenshots_to_vid_while_only_when_idle_or_plugged_in,
         foreground_window_video_background_color,
         is_record_system_sound,
+        record_audio_device_name,
         record_foreground_window_process_name,
         record_deep_linking,
         support_ocr_lst,
@@ -185,6 +186,7 @@ class Config:
         )
         self.foreground_window_video_background_color = foreground_window_video_background_color
         self.is_record_system_sound = is_record_system_sound
+        self.record_audio_device_name = record_audio_device_name
         self.record_foreground_window_process_name = record_foreground_window_process_name
         self.record_deep_linking = record_deep_linking
         self.support_ocr_lst = support_ocr_lst

--- a/windrecorder/config_src/config_default.json
+++ b/windrecorder/config_src/config_default.json
@@ -90,6 +90,7 @@
   "ocr_compare_similarity_in_table": 0.94,
   "convert_screenshots_to_vid_while_only_when_idle_or_plugged_in": false,
   "is_record_system_sound": false,
+  "record_audio_device_name":"Stereo Mix",
   "record_foreground_window_process_name": true,
   "record_deep_linking": true,
   "support_ocr_lst": [

--- a/windrecorder/config_src/languages.json
+++ b/windrecorder/config_src/languages.json
@@ -135,6 +135,9 @@
         "rs_text_ffmpeg_help": "- Designed for high-performance users needing comprehensive computer activity recordings;\n- Skip custom content/window during indexing, but related screens may still be captured without retrieval;\n- Memory-intensive recording process, indexing may consume additional system resources;\n- Up to a 15-minute delay in backtracking available;",
         "rs_text_screenshot_array_help": "- Ideal for most users who store, recall, and search for memory clues;\n- Efficient, real-time, and updates only changed images;\n- Instant screen replay; auto-converts screenshots to video;\n- Skip specific content/window; record only foreground window;",
         "rs_checkbox_is_record_system_sound": "Record system sound",
+        "rs_text_record_system_sound_help": "Currently only supports recording audio, and does not yet support audio-to-text retrieval.",
+        "rs_selectbox_audio_device": "Record audio input source",
+        "rs_text_audio_device_help": "When you want to record system content sound, please select the one containing Stereo Mix.",
         "rs_checkbox_convert_screenshots_to_vid_while_only_when_idle_or_plugged_in": "(Energy saving) Convert screenshots to videos only when idle or plugged in",
 
         "set_md_title": "### ⚙️ Settings",
@@ -395,6 +398,9 @@
         "rs_text_ffmpeg_help": "- 适用于想完整记录电脑活动视频、性能较高的用户；\n- 索引时可以跳过自定义窗口与内容，但相关画面仍可能被录制、只是无法被检索到；\n- 录制时将占用较高的内存，在录制完成索引时可能占用较多系统资源；\n- 回溯存在最多15分钟的延迟；",
         "rs_text_screenshot_array_help": "- 适用于存储、回忆、搜索记忆线索的大多数用户；\n- 占用低系统资源，实时分析、只索引存在变化的画面；\n- 可以马上回溯已记录画面；截图完毕会自动转换为视频；\n- 可以精确跳过自定义窗口与内容，同时可以仅录制前台窗口；",
         "rs_checkbox_is_record_system_sound": "同时录制系统声音",
+        "rs_text_record_system_sound_help": "目前仅支持录制音频，尚不支持音频转文本进行检索。",
+        "rs_selectbox_audio_device": "录制音频输入来源",
+        "rs_text_audio_device_help": "当想要录制系统内容声音时，请选择含有 Stereo Mix 的一项。",
         "rs_checkbox_convert_screenshots_to_vid_while_only_when_idle_or_plugged_in": "（节能）仅在电脑空闲时或接入电源时将截图转换为视频",
         
         "set_md_title": "### ⚙️ 设置",
@@ -656,6 +662,9 @@
         "rs_text_ffmpeg_help": "- コンピュータアクティビティのビデオを完全に録画し、高いパフォーマンスを実現したいユーザーに適しています。\n- インデックス作成中にカスタム ウィンドウとコンテンツをスキップできますが、関連する画像は記録される可能性がありますが、取得することはできません。\n n- 記録はより多くのメモリを占有し、記録が完了してインデックスが作成されると、より多くのシステム リソースを占有する可能性があります。\n- トレースバックには最大 15 分の遅延が発生します。",
         "rs_text_screenshot_array_help": "- メモリの手がかりを保存、呼び出し、検索するほとんどのユーザーに適しています。\n- 占有するシステム リソースが少なく、リアルタイムで分析し、変更された画像のみにインデックスを作成します。\n- 記録された画像はすぐに呼び出すことができ、完了後に自動的にビデオに変換されます。\n - カスタマイズされたウィンドウとコンテンツは正確にスキップでき、前景ウィンドウのみを記録できます。",
         "rs_checkbox_is_record_system_sound": "システムサウンドを同時に録音します",
+        "rs_text_record_system_sound_help": "現在サポートされているのは音声録音のみであり、取得のための音声のテキストへの変換はまだサポートされていません。",
+        "rs_selectbox_audio_device": "オーディオ入力ソースを録音",
+        "rs_text_audio_device_help": "システム コンテンツの音声を録音する場合は、ステレオ ミックスが含まれているものを選択してください。",
         "rs_checkbox_convert_screenshots_to_vid_while_only_when_idle_or_plugged_in": "(省電力) コンピューターがアイドル状態または電源に接続されている場合にのみ、スクリーンショットをビデオに変換します",
 
         "set_md_title": "### ⚙️ 設定",

--- a/windrecorder/record.py
+++ b/windrecorder/record.py
@@ -94,6 +94,21 @@ def record_screen_via_ffmpeg(
             CONFIG_RECORD_PRESET[encoder_preset_name]["ffmpeg_cmd"], int(config.record_bitrate) * (len(display_info) - 1)
         )
 
+    # Using ffmpeg to specify the recording audio device is not robust enough and is prone to errors due to IO permissions
+
+    # record_audio_args = []
+    # if config.is_record_system_sound and config.record_audio_device_name in utils.get_audio_input_devices():
+    #     record_audio_args = [
+    #         "-f",
+    #         "dshow",
+    #         "-i",
+    #         f'audio="{config.record_audio_device_name}"',
+    #         "-tune",
+    #         "zerolatency",
+    #         "-acodec",
+    #         "aac"
+    #     ]
+
     ffmpeg_cmd = [
         config.ffmpeg_path,
         "-hwaccel",

--- a/windrecorder/ui/recording.py
+++ b/windrecorder/ui/recording.py
@@ -30,6 +30,7 @@ def render():
     convert_screenshots_to_vid_while_only_when_idle_or_plugged_in = (
         config.convert_screenshots_to_vid_while_only_when_idle_or_plugged_in
     )
+    record_audio_device_name = config.record_audio_device_name
 
     st.markdown(_t("rs_md_title"))
 
@@ -79,12 +80,32 @@ def render():
                 st.image("__assets__\\record_method_ffmpeg.png")
             with record_mode_col_tip2:
                 st.markdown(_t("rs_text_ffmpeg_help"))
+
             is_record_system_sound = st.checkbox(
                 _t("rs_checkbox_is_record_system_sound"),
                 config.is_record_system_sound,
-                disabled=True,
-                help="Features still work in progress, please stay tuned.",
+                help=_t("rs_text_record_system_sound_help"),
             )
+            if is_record_system_sound:
+                try:
+                    if "system_audio_input_devices" not in st.session_state:
+                        st.session_state["system_audio_input_devices"] = utils.get_audio_input_devices()
+                    if config.record_audio_device_name in st.session_state.system_audio_input_devices:
+                        record_audio_device_name_index = [
+                            i
+                            for i, v in enumerate(st.session_state.system_audio_input_devices)
+                            if i == config.record_audio_device_name
+                        ][0]
+                    else:
+                        record_audio_device_name_index = 0
+                    record_audio_device_name = st.selectbox(
+                        _t("rs_selectbox_audio_device"),
+                        options=st.session_state.system_audio_input_devices,
+                        index=record_audio_device_name_index,
+                        help=_t("rs_text_audio_device_help"),
+                    )
+                except Exception as e:
+                    st.error(f"Fail to get audio device info: {e}")
 
         elif record_mode == record_mode_option[1][1]:  # screenshot_array
             record_screenshot_method_capture_foreground_window_only = st.checkbox(
@@ -315,6 +336,7 @@ def render():
                 convert_screenshots_to_vid_while_only_when_idle_or_plugged_in,
             )
             config.set_and_save_config("is_record_system_sound", is_record_system_sound)
+            config.set_and_save_config("record_audio_device_name", record_audio_device_name)
 
             config.set_and_save_config("screentime_not_change_to_pause_record", screentime_not_change_to_pause_record)
             config.set_and_save_config("start_recording_on_startup", is_start_recording_on_start_app)

--- a/windrecorder/utils.py
+++ b/windrecorder/utils.py
@@ -18,6 +18,7 @@ from io import BytesIO
 import cv2
 import mss
 import psutil
+import pyaudio
 import requests
 from PIL import Image
 from pyshortcuts import make_shortcut
@@ -903,3 +904,17 @@ def print_table(data: list, indentation_cnt=0):
     for row in data:
         formatted_row = [format_string(str(x), col_width[i]) for i, x in enumerate(row)]
         print(" " * indentation_cnt + "    ".join(formatted_row))
+
+
+def get_audio_input_devices():
+    """
+    获取音频输入设备列表
+    """
+    p = pyaudio.PyAudio()
+    input_devices = []
+    for i in range(p.get_device_count()):
+        device_info = p.get_device_info_by_index(i)
+        if device_info["maxInputChannels"] > 0:
+            input_devices.append(device_info["name"])
+    p.terminate()
+    return input_devices


### PR DESCRIPTION
Using ffmpeg to specify the recording audio device is not robust enough and is prone to errors due to IO permissions.

Consider using pyaudio to record in another thread and merge it with the video afterwards. This design can also be adapted to the flexible screenshot mode.

This PR does not include audio-to-text retrieval, and only supports video recording of desktop audio.