### PR TITLE
fix search timestamp when performing img embedding search

### DIFF
--- a/windrecorder/utils.py
+++ b/windrecorder/utils.py
@@ -357,7 +357,7 @@ def calc_vid_inside_time(df, num):
     # 用记录时的总时间减去视频文件时间（开始记录的时间）即可得到相对的时间
     vid_timestamp = fulltime - dtstr_to_seconds(vidfilename)
     logger.info(f"utils: video file fulltime:{fulltime}\n" f" vidfilename:{vidfilename}\n" f" vid_timestamp:{vid_timestamp}\n")
-    return vid_timestamp
+    return abs(vid_timestamp)
 
 
 # 估计索引时间


### PR DESCRIPTION
进行图像语义搜索时，有时会报错：

```
StreamlitAPIException: Invalid start_time and end_time combination.

Traceback:
File "E:\Windrecorder\webui.py", line 115, in <module>
    main_webui()
File "E:\Windrecorder\webui.py", line 80, in main_webui
    windrecorder.ui.search.render()
File "E:\Windrecorder\windrecorder\ui\search.py", line 190, in render
    show_and_locate_video_timestamp_by_df(df, result_choose_num)
File "E:\Windrecorder\windrecorder\ui\search.py", line 522, in show_and_locate_video_timestamp_by_df
    st.video(video_bytes, start_time=st.session_state.vid_vid_timestamp)
```

检查发现是utils中的`calc_vid_inside_time`函数返回值为负，函数逻辑没问题，但不知道为什么有时候`fulltime`会比`vidfilename`大，可能是保存时的问题，具体日志如下：
```
2024-10-21 16:59:10,458 - [utils.py:359] - calc_vid_inside_time - INFO - utils: video file fulltime:1729507613
 vidfilename:2024-10-21_10-46-58
 vid_timestamp:-5
```

临时解决方案为返回时长的绝对值
如果需要更多信息，我很乐意提供！